### PR TITLE
adding --quiet to mongodump call

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -101,15 +101,15 @@ function BackupMongoDatabase(config) {
         let DB_BACKUP_NAME = `${database}_${currentTime(timezoneOffset)}.gz`;
 
         // Default command, does not considers username or password
-        let command = `mongodump -h ${host} --port=${port} -d ${database} --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
+        let command = `mongodump -h ${host} --port=${port} -d ${database} --quiet --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
 
         // When Username and password is provided
         if (username && password) {
-            command = `mongodump -h ${host} --port=${port} -d ${database} -p ${password} -u ${username} --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
+            command = `mongodump -h ${host} --port=${port} -d ${database} -p ${password} -u ${username} --quiet --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
         }
         // When Username is provided
         if (username && !password) {
-            command = `mongodump -h ${host} --port=${port} -d ${database} -u ${username} --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
+            command = `mongodump -h ${host} --port=${port} -d ${database} -u ${username} --quiet --gzip --archive=${BACKUP_PATH(DB_BACKUP_NAME)}`;
         }
 
         exec(command, (err, stdout, stderr) => {


### PR DESCRIPTION
When using s3-mongo-backup for my own project, i bump in a mongodump error : failed error reading from db EOF. 
Of course stackoverflow save my life once again : 

https://stackoverflow.com/questions/36031857/mongodump-error-failed-error-reading-from-db-eof-no-entries-in-server-log

it works !

so i juste add "--quiet" to the 3 mongodump call.
